### PR TITLE
Force the website to be served only over https

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -12,6 +12,7 @@ handlers:
 - url: /
   static_files: index.html
   upload: index.html
+  secure: always
 
 - url: /icon_128\.png
   static_files: cws/icon_128.png

--- a/cws/manifest.json
+++ b/cws/manifest.json
@@ -10,7 +10,7 @@
   },
   "app" : {
     "launch" : {
-      "web_url" : "http://www.driveplayer.com/"
+      "web_url" : "https://www.driveplayer.com/"
     }
   }
 }


### PR DESCRIPTION
The domain for this demo app (www.driveplayer.com) now supports SSL. We should make sure users are only using it